### PR TITLE
fix: correct typos kernal→kernel and realisitic→realistic

### DIFF
--- a/AboutData.qmd
+++ b/AboutData.qmd
@@ -37,7 +37,7 @@ this species).  For the remaining species, filtered data were grouped to
 identify generic values for teleosts and sharks.  Data for albacore tuna from 
 @Barnes2008 were [combined](https://github.com/noaa-pifsc/Pelagic-mizer-model/blob/main/ModelBuild/DietData/AlbacoreDietData.Rmd) 
 with albacore tuna diet data from @Pinnegar2015 and @Goni2014.  These data 
-informed feeding kernal parameters.
+informed feeding kernel parameters.
 
 Information for remaining parameters was taken from the literature (see @sec-SpeciesParams).
 When data for needed parameters wasn't in the literature, we turned to [FishLife](https://james-thorson-noaa.github.io/FishLife/)

--- a/ImproveFit.qmd
+++ b/ImproveFit.qmd
@@ -154,7 +154,7 @@ The species in this model are nearly all apex predators.  The limited diet
 studies available suggest that they primarily eat species other than each other. 
 For this reason, we extend the background resource for the full size range of 
 fish modeled.  As a result, most of the predation is of the background resource.
-While this is probably realisitic, it does mean that there's very little in the
+While this is probably realistic, it does mean that there's very little in the
 model in the way of predator-prey interactions.  Changing one species has 
 little effect on other species. This could be changed by rethinking how
 predation is modeled. For example, the maximum size of the background resource


### PR DESCRIPTION
## Summary
Fixes 2 typos identified in issue #24:
- AboutData.qmd line 40: `kernal` → `kernel`
- ImproveFit.qmd line 157: `realisitic` → `realistic`

## Changes
- `AboutData.qmd` (1 line): `kernal` → `kernel`
- `ImproveFit.qmd` (1 line): `realisitic` → `realistic`

## Testing
- Verified no other instances of these typos remain in .qmd source files

Closes #24